### PR TITLE
Set quoted identiferes ignore case session parameter

### DIFF
--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -29,6 +29,7 @@ export default class SnowflakeDriver extends AbstractDriver<DriverLib, DriverOpt
     try {
       const conn = new Snowflake(connOptions);
       await conn.connect();
+      await conn.execute('ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE');
       this.connection = Promise.resolve(conn);
     } catch (error) {
       return Promise.reject(error);


### PR DESCRIPTION
Fixes #10 

The driver fails to connect for cases where the QUOTED_IDENTIFIERS_IGNORE_CASE in the snowflake account/user is set to True. This PR sets `QUOTED_IDENTIFIERS_IGNORE_CASE` session parameter to False. 